### PR TITLE
Rename organization primary key

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,6 +10,9 @@ use Mix.Config
 config :liquid_voting_auth,
   ecto_repos: [LiquidVotingAuth.Repo]
 
+config :liquid_voting_auth, LiquidVotingAuth.Repo,
+  migration_primary_key: [name: :id, type: :binary_id]
+
 # Configures the endpoint
 config :liquid_voting_auth, LiquidVotingAuthWeb.Endpoint,
   url: [host: "localhost"],

--- a/lib/liquid_voting_auth/organizations.ex
+++ b/lib/liquid_voting_auth/organizations.ex
@@ -33,7 +33,7 @@ defmodule LiquidVotingAuth.Organizations do
       ** (Ecto.NoResultsError)
 
   """
-  def get_organization!(uuid), do: Repo.get!(Organization, uuid)
+  def get_organization!(id), do: Repo.get!(Organization, id)
 
   @doc """
   Checks if an organization with given auth key exists

--- a/lib/liquid_voting_auth/organizations/organization.ex
+++ b/lib/liquid_voting_auth/organizations/organization.ex
@@ -2,7 +2,7 @@ defmodule LiquidVotingAuth.Organizations.Organization do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @primary_key {:uuid, :binary_id, autogenerate: true}
+  @primary_key {:id, :binary_id, autogenerate: true}
 
   schema "organizations" do
     field :auth_key, Ecto.UUID, autogenerate: true

--- a/lib/liquid_voting_auth_web/controllers/auth_controller.ex
+++ b/lib/liquid_voting_auth_web/controllers/auth_controller.ex
@@ -10,7 +10,7 @@ defmodule LiquidVotingAuthWeb.AuthController do
     ) do
       if org = registered?(auth_key) do
         conn
-        |> put_resp_header("org-uuid", org.uuid)
+        |> put_resp_header("org-uuid", org.id)
         |> send_resp(200, "")
       else
         conn |> send_resp(401, "")

--- a/priv/repo/migrations/20200512153435_create_organizations.exs
+++ b/priv/repo/migrations/20200512153435_create_organizations.exs
@@ -2,8 +2,7 @@ defmodule LiquidVotingAuth.Repo.Migrations.CreateOrganizations do
   use Ecto.Migration
 
   def change do
-    create table(:organizations, primary_key: false) do
-      add :uuid, :uuid, primary_key: true
+    create table(:organizations) do
       add :auth_key, :uuid, null: false
       add :name, :string
 

--- a/test/liquid_voting_auth/organizations_test.exs
+++ b/test/liquid_voting_auth/organizations_test.exs
@@ -24,12 +24,12 @@ defmodule LiquidVotingAuth.OrganizationsTest do
       assert Organizations.list_organizations() == [organization]
     end
 
-    test "get_organization!/1 returns the organization with given uuid" do
+    test "get_organization!/1 returns the organization with given id" do
       organization = organization_fixture()
-      assert Organizations.get_organization!(organization.uuid) == organization
+      assert Organizations.get_organization!(organization.id) == organization
     end
 
-    test "get_organization_with_auth_key/1 returns org uuid when organization is found with given auth key" do
+    test "get_organization_with_auth_key/1 returns org id when organization is found with given auth key" do
       organization = organization_fixture()
       assert Organizations.get_organization_with_auth_key(organization.auth_key) == organization
     end
@@ -70,7 +70,7 @@ defmodule LiquidVotingAuth.OrganizationsTest do
       assert {:error, %Ecto.Changeset{}} =
                Organizations.update_organization(organization, @invalid_attrs)
 
-      assert organization == Organizations.get_organization!(organization.uuid)
+      assert organization == Organizations.get_organization!(organization.id)
     end
 
     test "delete_organization/1 deletes the organization" do
@@ -78,7 +78,7 @@ defmodule LiquidVotingAuth.OrganizationsTest do
       assert {:ok, %Organization{}} = Organizations.delete_organization(organization)
 
       assert_raise Ecto.NoResultsError, fn ->
-        Organizations.get_organization!(organization.uuid)
+        Organizations.get_organization!(organization.id)
       end
     end
 

--- a/test/liquid_voting_auth_web/controllers/auth_controller_test.exs
+++ b/test/liquid_voting_auth_web/controllers/auth_controller_test.exs
@@ -25,7 +25,7 @@ defmodule LiquidVotingAuthWeb.AuthControllerTest do
         |> Plug.Conn.put_req_header("authorization", "Bearer " <> auth_key)
         |> get("/_external-auth")
 
-      assert Plug.Conn.get_resp_header(conn, "org-uuid") == [organization.uuid]
+      assert Plug.Conn.get_resp_header(conn, "org-uuid") == [organization.id]
     end
   end
 


### PR DESCRIPTION
This addresses issue [#28](https://github.com/liquidvotingio/auth/issues/28)  "Change p_key name to 'id' from 'uuid'".

Notes:
  1. Auth header not changed from "org-uuid" as this requires coordinating across other repos. including the api, ruby client, and deployment, and is covered by issue [#78](https://github.com/liquidvotingio/api/issues/78): "Change use of org-uuid to org-id in headers".
  2. In `config/config.exs` I inserted;
  ```
  config :liquid_voting_auth, LiquidVotingAuth.Repo,
    migration_primary_key: [name: :id, type: :binary_id]
  ```
and removed the primary-key related commands from the migration `priv/repo/migrations/20200512153435_create_organizations.exs`, as per the changes to the primary-keys in the api.  

  3. Although I have manually tested every action in `lib/liquid_voting_auth/organizations.ex`, and also all tests pass, I have not tested externally (e.g. with curl requests) as I do not know how to get the docker image running correctly (i.e. I managed to download and run the image, but the bash commands in the readme fail in ways I don't yet understand). I would appreciate help in learning how to run the curl tests / docker image.
