### PR TITLE
Remove TTY option from deployment

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -100,7 +100,7 @@ jobs:
         kubectl rollout restart deployment/auth-deployment
         pod=$(kubectl get pods -l app=auth  -o json | jq -r '.items[].metadata.name' | head -1)
         kubectl wait --timeout=120s --for=condition=Ready pod/$pod
-        kubectl exec -ti pod/$pod \
+        kubectl exec -i pod/$pod \
         --container auth-container \
         -- /home/myuser/bin/liquid_voting_auth \
         eval "LiquidVotingAuth.Release.migrate"
@@ -139,7 +139,7 @@ jobs:
           gcloud container clusters get-credentials $GKE_CLUSTER --zone $GKE_ZONE --project $GKE_PROJECT
           pod=$(kubectl get pods -l app=api  -o json | jq -r '.items[].metadata.name' | head -1)
           kubectl wait --timeout=120s --for=condition=Ready pod/$pod
-          kubectl exec -ti pod/$pod \
+          kubectl exec -i pod/$pod \
           --container api-container \
           -- /opt/app/bin/liquid_voting \
           eval "LiquidVoting.Release.smoke_test_teardown"


### PR DESCRIPTION
To fix the `Unable to use a TTY - input is not a terminal or the right kind of file` warning on some builds like https://github.com/liquidvotingio/auth/runs/976958232?check_suite_focus=true (see Deploy to GKE > Deploy step)

https://stackoverflow.com/questions/60826194/kubectl-exec-fails-with-the-error-unable-to-use-a-tty-input-is-not-a-terminal