### PR TITLE
Linode deploy

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -105,40 +105,32 @@ jobs:
         eval "LiquidVotingAuth.Release.migrate"
 
   smoke_tests:
-      name: Smoke Tests
-      needs: [deploy]
-      runs-on: ubuntu-latest
-      steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          repository: liquidvotingio/deployment
-          token: ${{ secrets.DEPLOYMENT_PAT }}
-          path: deployment
-      - name: Run k6 smoke tests
-        uses: k6io/action@v0.1
-        env:
-          TEST_API_AUTH_KEY: ${{ secrets.TEST_API_AUTH_KEY }}
-        with:
-          filename: deployment/smoke_tests/smoke_tests.js
-      - name: Login to gcloud
-        if: always()
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-        with:
-          version: '270.0.0'
-          service_account_email: ${{ secrets.GKE_EMAIL }}
-          service_account_key: ${{ secrets.GKE_KEY }}
-      - name: Teardown smoke test data
-        if: always()
-        env:
-          GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
-          GKE_ZONE: ${{ secrets.GKE_ZONE }}
-          GKE_PROJECT: ${{ secrets.GKE_PROJECT }}
-        run: |
-          gcloud container clusters get-credentials $GKE_CLUSTER --zone $GKE_ZONE --project $GKE_PROJECT
-          pod=$(kubectl get pods -l app=api  -o json | jq -r '.items[].metadata.name' | head -1)
-          kubectl wait --timeout=120s --for=condition=Ready pod/$pod
-          kubectl exec -i pod/$pod \
-          --container api-container \
-          -- /opt/app/bin/liquid_voting \
-          eval "LiquidVoting.Release.smoke_test_teardown"
+    name: Smoke Tests
+    needs: [deploy]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        repository: liquidvotingio/deployment
+        token: ${{ secrets.DEPLOYMENT_PAT }}
+        path: deployment
+    - name: Run k6 smoke tests
+      uses: k6io/action@v0.1
+      env:
+        TEST_API_AUTH_KEY: ${{ secrets.TEST_API_AUTH_KEY }}
+      with:
+        filename: deployment/smoke_tests/smoke_tests.js
+    - name: Teardown smoke test data
+      if: always()
+      env:
+        KUBE_CONFIG_DATA: ${{ secrets.LINODE_KUBE_CONFIG }}
+      run: |
+        echo "$KUBE_CONFIG_DATA" | base64 --decode > /tmp/config
+        export KUBECONFIG=/tmp/config
+        pod=$(kubectl get pods -l app=api  -o json | jq -r '.items[].metadata.name' | head -1)
+        kubectl wait --timeout=120s --for=condition=Ready pod/$pod
+        kubectl exec -i pod/$pod \
+        --container api-container \
+        -- /opt/app/bin/liquid_voting \
+        eval "LiquidVoting.Release.smoke_test_teardown"

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -92,11 +92,10 @@ jobs:
         service_account_key: ${{ secrets.GKE_KEY }}
     - name: Deploy
       env:
-        GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
-        GKE_ZONE: ${{ secrets.GKE_ZONE }}
-        GKE_PROJECT: ${{ secrets.GKE_PROJECT }}
+        KUBE_CONFIG_DATA: ${{ secrets.LINODE_KUBE_CONFIG }}
       run: |
-        gcloud container clusters get-credentials $GKE_CLUSTER --zone $GKE_ZONE --project $GKE_PROJECT
+        echo "$KUBE_CONFIG_DATA" | base64 --decode > /tmp/config
+        export KUBECONFIG=/tmp/config
         kubectl rollout restart deployment/auth-deployment
         pod=$(kubectl get pods -l app=auth  -o json | jq -r '.items[].metadata.name' | head -1)
         kubectl wait --timeout=120s --for=condition=Ready pod/$pod


### PR DESCRIPTION
Updates deployment to use Linode, as in https://github.com/liquidvotingio/api/pull/134

Also adds smoke testing! Finally. (I know, should've been on a separate PR, but I'd like to see smoke tests running after we update deployment here)

Part of https://github.com/liquidvotingio/deployment/issues/35. Needs to be done in coordination with domain migration (see https://github.com/liquidvotingio/deployment/issues/10)